### PR TITLE
Fixing a broken link for create-policy CLI

### DIFF
--- a/doc_source/orgs_manage_policies_scp.md
+++ b/doc_source/orgs_manage_policies_scp.md
@@ -123,7 +123,7 @@ You can use this option to create a new SCP using the editor\. Don't select a po
 **To create a service control policy \(AWS CLI, AWS API\)**  
 You can use the following commands to create an SCP:
 
-+ AWS CLI: [aws organizations create\-policy](http://docs.aws.amazon.com/cli/latest/reference/organizations/create-account.html)
++ AWS CLI: [aws organizations create\-policy](http://docs.aws.amazon.com/cli/latest/reference/organizations/create-policy.html)
 
 + AWS API: [CreatePolicy](http://docs.aws.amazon.com/organizations/latest/APIReference/API_CreatePolicy.html)
 


### PR DESCRIPTION
The existing link for create-policy was pointing to create-account. The fix was to change it to create-policy.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
