### PR TITLE
Updating example CloudTrail SCP to also prevent deleting a trail.

### DIFF
--- a/doc_source/orgs_manage_policies_example-scps.md
+++ b/doc_source/orgs_manage_policies_example-scps.md
@@ -6,7 +6,7 @@ Each of the following policies is an example of a [blacklist policy](orgs_manage
 
 ## Example 1: Prevent Users from Disabling AWS CloudTrail<a name="example_scp_1"></a>
 
-This SCP prevents users or roles in any affected account from disabling a CloudTrail log, either directly as a command or through the console\.
+This SCP prevents users or roles in any affected account from disabling or deleting a CloudTrail log, either directly as a command or through the console\.
 
 ```
 {
@@ -14,7 +14,10 @@ This SCP prevents users or roles in any affected account from disabling a CloudT
   "Statement": [
     {
       "Effect": "Deny",
-      "Action": "cloudtrail:StopLogging",
+      "Action": [
+        "cloudtrail:StopLogging",
+        "cloudtrail:DeleteTrail"
+      ],
       "Resource": "*"
     }
   ]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The Service Control Policy (SCP) example for CloudTrail is meant to prevent users from disabling CloudTrail on an account. While it does prevent users from executing `StopLogging` on a trail, users are still able to outright delete a trail using the `DeleteTrail` action. Which has the same outcome of disabling CloudTrail.

This change updates the example SCP to also deny the `DeleteTrail` action so that CloudTrail is more comprehensively protected from being disabled or deleted.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.