### PR TITLE
Removed "Escalations" from line 491

### DIFF
--- a/doc_source/orgs_manage_policies_inheritance_mgmt.md
+++ b/doc_source/orgs_manage_policies_inheritance_mgmt.md
@@ -487,8 +487,7 @@ You can't directly use the contents of a displayed effective policy as the conte
         "project": {
             "tag_key": " PROJECT",
             "tag_value": [
-                "Maintenance",
-                "Escalations"
+                "Maintenance"
             ]
         }
     }


### PR DESCRIPTION
"Escalations" is not a tag value from any of the root policies for Example 6. Hence removed the tag value

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
