### PR TITLE
Update services-that-can-integrate-audit-manager.md

### DIFF
--- a/doc_source/services-that-can-integrate-audit-manager.md
+++ b/doc_source/services-that-can-integrate-audit-manager.md
@@ -111,7 +111,7 @@ If you want to configure a delegated administrator account using the AWS CLI or 
 + AWS CLI: 
 
   ```
-  $  aws audit-manager register-account \
+  $  aws auditmanager register-account \
       --delegated-admin-account 123456789012
   ```
 + AWS SDK: Call the `RegisterAccount` operation and provide `delegatedAdminAccount` as a parameter to delegate the administrator account\. 


### PR DESCRIPTION
AWS CLI command for Audit Manager is one word 'auditmanager' not 'audit-manager' as was in the docs.

See: https://docs.aws.amazon.com/cli/latest/reference/auditmanager/index.html

*Issue #, if available:* N/A

*Description of changes:* Corrected AWS CLI command for register a delegated administrator account for Audit Manager.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
