### PR TITLE
Add ec2:CreateDefaultVpc to block list

### DIFF
--- a/doc_source/orgs_manage_policies_scps_examples_vpc.md
+++ b/doc_source/orgs_manage_policies_scps_examples_vpc.md
@@ -38,6 +38,7 @@ This SCP prevents users or roles in any affected account from changing the confi
       "Action": [
         "ec2:AttachInternetGateway",
         "ec2:CreateInternetGateway",
+        "ec2:CreateDefaultVpc",
         "ec2:CreateEgressOnlyInternetGateway",
         "ec2:CreateVpcPeeringConnection",
         "ec2:AcceptVpcPeeringConnection",


### PR DESCRIPTION
ec2:CreateDefaultVpc bypasses ec2:CreateInternetGateway as per https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html 

```
Amazon creates the above resources on your behalf. IAM policies do not apply to these actions because you do not perform these actions. For example, if you have an IAM policy that denies the ability to call CreateInternetGateway, and then you call CreateDefaultVpc, the internet gateway in the default VPC is still created.
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
